### PR TITLE
hide error when edittext is valid implemented

### DIFF
--- a/core/src/main/java/com/sha/formvalidator/textview/DefTextValidationHandler.kt
+++ b/core/src/main/java/com/sha/formvalidator/textview/DefTextValidationHandler.kt
@@ -96,6 +96,9 @@ class DefTextValidationHandler : TextValidationHandler {
     override fun validate(showError: Boolean): Boolean {
         val isValid = mValidator.isValid(editText.text.toString())
         if (!isValid && showError) showError()
+        else if(isValid && showError){
+            hideError()
+        }
         return isValid
     }
 
@@ -108,6 +111,15 @@ class DefTextValidationHandler : TextValidationHandler {
         }
 
         editText.error = mValidator.errorMessage
+    }
+
+    override fun hideError() {
+        if (hasTextInputLayout()) {
+            textInputLayout().error = null
+            return
+        }
+
+        editText.error = null
     }
 
     private fun hasTextInputLayout(): Boolean {

--- a/core/src/main/java/com/sha/formvalidator/textview/TextValidationHandler.kt
+++ b/core/src/main/java/com/sha/formvalidator/textview/TextValidationHandler.kt
@@ -34,4 +34,6 @@ interface TextValidationHandler {
 
     fun showError()
 
+    fun hideError()
+
 }


### PR DESCRIPTION
Hi, I've realized that there is no way to remove error from edittext so I've made a little improvement